### PR TITLE
correct filepath in errors

### DIFF
--- a/connectors/connector-lib/src/oracle_core.rs
+++ b/connectors/connector-lib/src/oracle_core.rs
@@ -190,7 +190,7 @@ impl OracleCore {
     }
 }
 
-/// Reads the local `oracle_config.yaml` file
+/// Reads the local `oracle-config.yaml` file
 fn get_config_yaml_string() -> Result<String> {
     std::fs::read_to_string("oracle-config.yaml")
         .map_err(|_| ConnectorError::FailedOpeningOracleConfigFile)

--- a/src/oracle_config.rs
+++ b/src/oracle_config.rs
@@ -69,9 +69,9 @@ pub fn get_core_api_port() -> String {
         .to_string()
 }
 
-/// Reads the `oracle_config.yaml` file
+/// Reads the `oracle-config.yaml` file
 pub fn get_config_yaml() -> String {
-    std::fs::read_to_string("oracle-config.yaml").expect("Failed to open oracle_config.yaml")
+    std::fs::read_to_string("oracle-config.yaml").expect("Failed to open oracle-config.yaml")
 }
 
 /// Returns `http://ip:port` using `node_ip` and `node_port` from the config file


### PR DESCRIPTION
We are actually looking for `oracle-config.yaml` not `oracle_config.yaml`. Just a cosmetic change, but took few minutes of my life. :)