### PR TITLE
Build and publish release artifacts in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - v[0-9]+.*
+  release:
+    types: [published]
 
 jobs:
   create-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,6 @@ on:
     types: [published]
 
 jobs:
-  create-release:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: taiki-e/create-gh-release-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   upload-assets:
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v[0-9]+.*
+
+jobs:
+  create-release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: taiki-e/create-gh-release-action@v1
+        # with:
+        #   # (optional)
+        #   changelog: CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-assets:
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-20.04
+            build_tool: cross # Use https://github.com/cross-rs/cross for ARM
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-20.04
+            build_tool: cargo
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            build_tool: cargo
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            build_tool: cargo
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        name: Install cross-compilation tools
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: oracle_core
+          target: ${{ matrix.target }}
+          build_tool: ${{ matrix.build_tool }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: taiki-e/create-gh-release-action@v1
-        # with:
-        #   # (optional)
-        #   changelog: CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Close #22

It supports ARM/x86 Linux, x86 Mac (note that we don't really need ARM because of Apple's x86 emulation with rosetta) and x86 Windows.

There is one complication with this implementation. The version tags must be of the form `vX.Y.Z`. This is because the Github action script I'm using expects this format: https://github.com/taiki-e/create-gh-release-action/blob/f8e035329c036c64d0ac5edc2852fffa67d7d6f4/main.sh#L35-L37.

I've tested this `yml` file in a separate repo: https://github.com/kettlebell/rust_hello_world/releases/tag/v1.0.1