### PR TITLE
Add warning for when git fails in build.rs

### DIFF
--- a/core/build.rs
+++ b/core/build.rs
@@ -11,26 +11,35 @@ fn run_command(bin: &str, args: &[&str]) -> Result<String, Box<dyn Error>> {
 }
 
 fn main() {
-    println!("cargo:rustc-env=GIT_COMMIT_INFO=");
-    if let Ok(git_path) = run_command("git", &["rev-parse", "--show-cdup"]) {
-        // Check whether .git repository belongs to oracle-core, since GitHub releases do not include .git
-        if git_path.trim_end() == "../" {
-            let mut commit_hash = String::new();
-            let mut commit_date = String::new();
-            match run_command("git", &["rev-parse", "HEAD"]) {
-                Ok(hash) => commit_hash = hash,
-                Err(e) => {
-                    println!("cargo:warning=Error getting commit hash, error: {}", e)
+    match run_command("git", &["rev-parse", "--show-cdup"]) {
+        Ok(git_path) => {
+            // Check whether .git repository belongs to oracle-core, since GitHub releases do not include .git
+            if git_path.trim_end() == "../" {
+                let mut commit_hash = String::new();
+                let mut commit_date = String::new();
+                match run_command("git", &["rev-parse", "HEAD"]) {
+                    Ok(hash) => commit_hash = hash,
+                    Err(e) => {
+                        println!("cargo:warning=Error getting commit hash, error: {}", e)
+                    }
                 }
-            }
-            match run_command("git", &["log", "-1", "--format=%cd"]) {
-                Ok(date) => commit_date = date,
-                Err(e) => {
-                    println!("cargo:warning=Error getting commit hash, error: {}", e)
+                match run_command("git", &["log", "-1", "--format=%cd"]) {
+                    Ok(date) => commit_date = date,
+                    Err(e) => {
+                        println!("cargo:warning=Error getting commit hash, error: {}", e)
+                    }
                 }
+                println!("cargo:rustc-env=GIT_COMMIT_HASH={}", &commit_hash[0..7]);
+                println!("cargo:rustc-env=GIT_COMMIT_DATE={}", commit_date);
             }
-            println!("cargo:rustc-env=GIT_COMMIT_HASH={}", &commit_hash[0..7]);
-            println!("cargo:rustc-env=GIT_COMMIT_DATE={}", commit_date);
+        }
+        Err(e) => {
+            println!(
+                "cargo:warning=Error getting commit hash, error: {}. Omitting commit hash",
+                e
+            );
+            println!("cargo:rustc-env=GIT_COMMIT_HASH= ");
+            println!("cargo:rustc-env=GIT_COMMIT_DATE= ");
         }
     };
 }

--- a/core/build.rs
+++ b/core/build.rs
@@ -6,7 +6,13 @@ fn run_command(bin: &str, args: &[&str]) -> Result<String, Box<dyn Error>> {
     if command.status.success() {
         String::from_utf8(command.stdout).map_err(|e| e.into())
     } else {
-        Err(format!("{} {:?} failed", bin, args).into())
+        Err(format!(
+            "{} {:?} failed, stderr = {:?}",
+            bin,
+            args,
+            String::from_utf8(command.stderr).unwrap()
+        )
+        .into())
     }
 }
 


### PR DESCRIPTION
Hi, it seems the coveralls pipeline has been failing in build.rs (git parse --show-cdup fails), which causes the program to fail to compile due to git env vars not being defined.

This PR doesn't really address the issue directly, but instead it warns of the failed command in build output, and replaces the env vars with blanks. Here's the error message from git itself inside the pipeline: 

>stderr = "fatal: detected dubious ownership in repository at '/__w/oracle-core/oracle-core'\nTo add an exception for this directory, call:\n\n\tgit config --global --add safe.directory /__w/oracle-core/oracle-core\n"