### PR TITLE
Add intstructions in the IncorrectNumberOfRewardTokensInOracleBox error;

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -370,7 +370,7 @@ fn handle_pool_command(command: Command, node_api: &NodeApi) {
                 oracle_token_address,
                 height,
             ) {
-                error!("Fatal transfer-oracle-token error: {:?}", e);
+                error!("Fatal transfer-oracle-token error: {}", e);
                 std::process::exit(exitcode::SOFTWARE);
             }
         }


### PR DESCRIPTION
Close #260

TODO:
- switch to `anyhow::Error` in other commands;
- switch to `thiserror` `#[from]` in error types(enums);
- ensure `Display` (not `Debug`) formatting for errors in logs;