### PR TITLE
Export Prometheus metrics

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "oracle-core"
 version = "2.0.0-beta9"
-authors = ["Robert Kornacki <11645932+robkorn@users.noreply.github.com>", "@greenhat", "@kettlebell", "@SethDusek"]
+authors = [
+    "Robert Kornacki <11645932+robkorn@users.noreply.github.com>",
+    "@greenhat",
+    "@kettlebell",
+    "@SethDusek",
+]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -29,19 +34,20 @@ ergo-lib = { workspace = true }
 ergo-node-interface = { git = "https://github.com/ergoplatform/ergo-node-interface-rust", rev = "143c2a3dc8fb772d1af37f1f1e1924067c6aad14" }
 # ergo-node-interface = { version = "0.4" }
 derive_more = "0.99"
-clap = {version = "4.2.4", features = ["derive"]}
+clap = { version = "4.2.4", features = ["derive"] }
 exitcode = "1.1.2"
 lazy_static = "1.4.0"
 once_cell = "1.15.0"
 futures = "0.3"
+prometheus = "0.13"
 
 [dev-dependencies]
-ergo-lib = { workspace = true, features = ["arbitrary"]}
-proptest = {version = "1.0.0"}
-proptest-derive = {version = "0.3.0"}
-sigma-test-util = {version = "0.3.0"}
-ergo-chain-sim = {version = "0.1.0", path="../ergo-chain-sim"}
-env_logger = {version = "0.10.0"}
-tokio-test = {version = "0.4"}
-pretty_assertions = {workspace = true}
+ergo-lib = { workspace = true, features = ["arbitrary"] }
+proptest = { version = "1.0.0" }
+proptest-derive = { version = "0.3.0" }
+sigma-test-util = { version = "0.3.0" }
+ergo-chain-sim = { version = "0.1.0", path = "../ergo-chain-sim" }
+env_logger = { version = "0.10.0" }
+tokio-test = { version = "0.4" }
+pretty_assertions = { workspace = true }
 expect-test = "1.0.1"

--- a/core/src/address_util.rs
+++ b/core/src/address_util.rs
@@ -1,9 +1,10 @@
-use ergo_lib::ergotree_ir::{
-    chain::address::{Address, AddressEncoder, AddressEncoderError},
-    mir::constant::{Constant, Literal},
-    serialization::{SigmaParsingError, SigmaSerializable, SigmaSerializationError},
-    sigma_protocol::sigma_boolean::ProveDlog,
-};
+use ergo_lib::ergo_chain_types::EcPoint;
+use ergo_lib::ergotree_ir::chain::address::Address;
+use ergo_lib::ergotree_ir::chain::address::AddressEncoderError;
+use ergo_lib::ergotree_ir::chain::address::NetworkAddress;
+use ergo_lib::ergotree_ir::chain::address::NetworkPrefix;
+use ergo_lib::ergotree_ir::serialization::SigmaParsingError;
+use ergo_lib::ergotree_ir::serialization::SigmaSerializationError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -22,126 +23,11 @@ pub enum AddressUtilError {
     Base16DecodeError(#[from] base16::DecodeError),
 }
 
-/// Given a P2S Ergo address, extract the hex-encoded serialized ErgoTree (script)
-pub fn address_to_tree(address: &str) -> Result<String, AddressUtilError> {
-    let address_parsed = AddressEncoder::unchecked_parse_network_address_from_str(address)?;
-    let script = address_parsed.address().script()?;
-    Ok(base16::encode_lower(&script.sigma_serialize_bytes()?))
-}
-
-/// Given a P2S Ergo address, convert it to a hex-encoded Sigma byte array constant
-pub fn address_to_bytes(address: &str) -> Result<String, AddressUtilError> {
-    let address_parsed = AddressEncoder::unchecked_parse_network_address_from_str(address)?;
-    let script = address_parsed.address().script()?;
-    Ok(base16::encode_lower(
-        &Constant::from(script.sigma_serialize_bytes()?).sigma_serialize_bytes()?,
-    ))
-}
-
-/// Given an Ergo P2PK Address, convert it to a raw hex-encoded EC point
-/// and prepend the type bytes so it is encoded and ready
-/// to be used in a register.
-pub fn address_to_raw_for_register(address: &str) -> Result<String, AddressUtilError> {
-    let address_parsed = AddressEncoder::unchecked_parse_network_address_from_str(address)?;
-    match address_parsed.address() {
-        Address::P2Pk(ProveDlog { h }) => Ok(base16::encode_lower(
-            &Constant::from(*h).sigma_serialize_bytes()?,
-        )),
-        Address::P2SH(_) | Address::P2S(_) => Err(AddressUtilError::ExpectedP2PK),
-    }
-}
-
-/// Given an Ergo P2PK Address, convert it to a raw hex-encoded EC point
-pub fn address_to_raw(address: &str) -> Result<String, AddressUtilError> {
-    let address_parsed = AddressEncoder::unchecked_parse_network_address_from_str(address)?;
-    match address_parsed.address() {
-        Address::P2Pk(_) => Ok(base16::encode_lower(
-            &address_parsed.address().content_bytes(),
-        )),
-        Address::P2SH(_) | Address::P2S(_) => Err(AddressUtilError::ExpectedP2PK),
-    }
-}
-
-/// Given a raw hex-encoded EC point, convert it to a P2PK address
-pub fn raw_to_address(raw: &str) -> Result<Address, AddressUtilError> {
-    let bytes = base16::decode(raw)?;
-    Address::p2pk_from_pk_bytes(&bytes).map_err(Into::into)
-}
-
-/// Given a raw hex-encoded EC point from a register (thus with type encoded characters in front),
-/// convert it to a P2PK address
-pub fn raw_from_register_to_address(raw: &str) -> Result<Address, AddressUtilError> {
-    let bytes = base16::decode(raw)?;
-    let constant = Constant::sigma_parse_bytes(&bytes)?;
-    if let Literal::GroupElement(h) = constant.v {
-        Ok(Address::P2Pk(ProveDlog { h }))
-    } else {
-        Err(AddressUtilError::ExpectedP2PK)
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use ergo_lib::ergotree_ir::chain::address::{AddressEncoder, NetworkPrefix};
-
-    use crate::address_util::{
-        address_to_bytes, address_to_raw, address_to_raw_for_register, address_to_tree,
-        raw_from_register_to_address, raw_to_address,
-    };
-
-    // Test serialization for default address argument of /utils/addressToRaw
-    #[test]
-    fn test_address_to_raw_for_register() {
-        assert_eq!(
-            "07028333f9f7454f8d5ff73dbac9833767ed6fc3a86cf0a73df946b32ea9927d9197",
-            address_to_raw_for_register("3WwbzW6u8hKWBcL1W7kNVMr25s2UHfSBnYtwSHvrRQt7DdPuoXrt")
-                .unwrap()
-        );
-        assert_eq!(
-            "028333f9f7454f8d5ff73dbac9833767ed6fc3a86cf0a73df946b32ea9927d9197",
-            address_to_raw("3WwbzW6u8hKWBcL1W7kNVMr25s2UHfSBnYtwSHvrRQt7DdPuoXrt").unwrap()
-        );
-    }
-    #[test]
-    fn test_address_raw_roundtrip() {
-        let address = AddressEncoder::new(NetworkPrefix::Testnet)
-            .parse_address_from_str("3WwbzW6u8hKWBcL1W7kNVMr25s2UHfSBnYtwSHvrRQt7DdPuoXrt")
-            .unwrap();
-        assert_eq!(
-            address,
-            raw_to_address(
-                &address_to_raw("3WwbzW6u8hKWBcL1W7kNVMr25s2UHfSBnYtwSHvrRQt7DdPuoXrt").unwrap()
-            )
-            .unwrap()
-        );
-    }
-    #[test]
-    fn test_address_raw_register_roundtrip() {
-        let address = AddressEncoder::new(NetworkPrefix::Testnet)
-            .parse_address_from_str("3WwbzW6u8hKWBcL1W7kNVMr25s2UHfSBnYtwSHvrRQt7DdPuoXrt")
-            .unwrap();
-        assert_eq!(
-            address,
-            raw_from_register_to_address(
-                &address_to_raw_for_register(
-                    "3WwbzW6u8hKWBcL1W7kNVMr25s2UHfSBnYtwSHvrRQt7DdPuoXrt"
-                )
-                .unwrap()
-            )
-            .unwrap()
-        );
-    }
-
-    // test serialization of "sigmaProp(true)" script
-    #[test]
-    fn test_address_to_tree() {
-        assert_eq!(
-            "10010101d17300",
-            address_to_tree("Ms7smJwLGbUAjuWQ").unwrap()
-        );
-        assert_eq!(
-            "0e0710010101d17300",
-            address_to_bytes("Ms7smJwLGbUAjuWQ").unwrap()
-        );
-    }
+pub fn pks_to_network_addresses(
+    pks: Vec<EcPoint>,
+    network_prefix: NetworkPrefix,
+) -> Vec<NetworkAddress> {
+    pks.into_iter()
+        .map(|pk| NetworkAddress::new(network_prefix, &Address::P2Pk(pk.into())))
+        .collect()
 }

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::box_kind::{OracleBoxWrapper, PoolBox};
 use crate::node_interface::node_api::NodeApi;
-use crate::oracle_config::{get_core_api_port, ORACLE_CONFIG};
+use crate::oracle_config::ORACLE_CONFIG;
 use crate::oracle_state::{DataSourceError, LocalDatapointState, OraclePool};
 use crate::pool_config::POOL_CONFIG;
 use axum::http::StatusCode;
@@ -268,6 +268,7 @@ fn pool_health_sync(oracle_pool: Arc<OraclePool>) -> Result<serde_json::Value, A
 pub async fn start_rest_server(
     repost_receiver: Receiver<bool>,
     oracle_pool: Arc<OraclePool>,
+    api_port: u16,
 ) -> Result<(), anyhow::Error> {
     let op_clone = oracle_pool.clone();
     let op_clone2 = oracle_pool.clone();
@@ -290,7 +291,7 @@ pub async fn start_rest_server(
                 .allow_origin(tower_http::cors::Any)
                 .allow_methods([axum::http::Method::GET]),
         );
-    let addr = SocketAddr::from(([0, 0, 0, 0], get_core_api_port().parse().unwrap()));
+    let addr = SocketAddr::from(([0, 0, 0, 0], api_port));
     axum::Server::try_bind(&addr)?
         .serve(app.into_make_service())
         .await?;

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -224,7 +224,7 @@ fn pool_health_sync(oracle_pool: Arc<OraclePool>) -> Result<serde_json::Value, A
         .get_box()
         .creation_height
         .into();
-    let pool_health = check_pool_health( current_height, pool_box_height)?;
+    let pool_health = check_pool_health(current_height, pool_box_height)?;
     Ok(serde_json::to_value(pool_health).unwrap())
 }
 

--- a/core/src/box_kind/oracle_box.rs
+++ b/core/src/box_kind/oracle_box.rs
@@ -175,11 +175,10 @@ impl OracleBox for OracleBoxWrapper {
     }
 
     fn public_key(&self) -> EcPoint {
-        self.get_box()
-            .get_register(NonMandatoryRegisterId::R4.into())
-            .unwrap()
-            .try_extract_into::<EcPoint>()
-            .unwrap()
+        match self {
+            OracleBoxWrapper::Posted(p) => p.public_key().clone(),
+            OracleBoxWrapper::Collected(c) => c.public_key().clone(),
+        }
     }
 
     fn get_box(&self) -> &ErgoBox {
@@ -275,6 +274,14 @@ impl PostedOracleBox {
 impl CollectedOracleBox {
     pub fn get_box(&self) -> &ErgoBox {
         &self.ergo_box
+    }
+
+    pub fn public_key(&self) -> EcPoint {
+        self.ergo_box
+            .get_register(NonMandatoryRegisterId::R4.into())
+            .unwrap()
+            .try_extract_into::<EcPoint>()
+            .unwrap()
     }
 }
 

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -57,8 +57,6 @@ use clap::{Parser, Subcommand};
 use crossbeam::channel::bounded;
 use datapoint_source::RuntimeDataPointSource;
 use ergo_lib::ergo_chain_types::Digest32;
-use ergo_lib::ergotree_ir::chain::address::Address;
-use ergo_lib::ergotree_ir::chain::address::NetworkAddress;
 use ergo_lib::ergotree_ir::chain::address::NetworkPrefix;
 use ergo_lib::ergotree_ir::chain::token::TokenAmount;
 use ergo_lib::ergotree_ir::chain::token::TokenId;
@@ -95,6 +93,7 @@ use std::thread;
 use std::time::Duration;
 
 use crate::actions::execute_action;
+use crate::address_util::pks_to_network_addresses;
 use crate::api::start_rest_server;
 use crate::default_parameters::print_contract_hashes;
 use crate::migrate::check_migration_to_split_config;
@@ -551,13 +550,12 @@ fn log_and_continue_if_non_fatal(
             found_public_keys,
             found_num,
         })) => {
-            let found_oracle_addresses: String = found_public_keys
-                .into_iter()
-                .map(|pk| {
-                    NetworkAddress::new(network_prefix, &Address::P2Pk(pk.into())).to_base58()
-                })
-                .collect::<Vec<String>>()
-                .join(", ");
+            let found_oracle_addresses: String =
+                pks_to_network_addresses(found_public_keys, network_prefix)
+                    .into_iter()
+                    .map(|net_addr| net_addr.to_base58())
+                    .collect::<Vec<String>>()
+                    .join(", ");
             log::error!("Refresh failed, not enough datapoints. The minimum number of datapoints within the deviation range: required minumum {expected}, found {found_num} from addresses {found_oracle_addresses},");
             Ok(None)
         }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -29,6 +29,7 @@ mod datapoint_source;
 mod default_parameters;
 mod explorer_api;
 mod logging;
+mod metrics;
 mod migrate;
 mod node_interface;
 mod oracle_config;

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -333,7 +333,7 @@ fn main() {
             if enable_rest_api {
                 let op_clone = oracle_pool.clone();
                 tokio_runtime.spawn(async {
-                    if let Err(e) = start_rest_server(repost_receiver, op_clone).await {
+                    if let Err(e) = start_rest_server(repost_receiver, op_clone, ORACLE_CONFIG.core_api_port).await {
                         error!("An error occurred while starting the REST server: {}", e);
                         std::process::exit(exitcode::SOFTWARE);
                     }

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -19,7 +19,6 @@ use tower_http::cors::CorsLayer;
 use crate::box_kind::PoolBox;
 use crate::monitor::check_oracle_health;
 use crate::monitor::check_pool_health;
-use crate::monitor::HealthStatus;
 use crate::monitor::OracleHealth;
 use crate::monitor::PoolHealth;
 use crate::node_interface::node_api::NodeApi;
@@ -214,11 +213,7 @@ fn update_pool_health(pool_health: &PoolHealth) {
     POOL_BOX_HEIGHT.set(pool_health.details.pool_box_height.into());
     CURRENT_HEIGHT.set(pool_health.details.current_height.into());
     EPOCH_LENGTH.set(pool_health.details.epoch_length.into());
-    let health = match pool_health.status {
-        HealthStatus::Ok => 1,
-        HealthStatus::Down => 0,
-    };
-    POOL_IS_HEALTHY.set(health);
+    POOL_IS_HEALTHY.set(pool_health.status as i64);
     for oracle in &pool_health.details.all_oracles {
         let box_type = oracle.box_height.label_name();
         let box_height = oracle.box_height.oracle_box_height().into();
@@ -242,12 +237,7 @@ fn update_oracle_health(oracle_health: &OracleHealth) {
     MY_ORACLE_BOX_HEIGHT
         .with_label_values(&[box_type])
         .set(oracle_health.details.box_details.oracle_box_height().into());
-
-    let health = match oracle_health.status {
-        HealthStatus::Ok => 1,
-        HealthStatus::Down => 0,
-    };
-    ORACLE_IS_HEALTHY.set(health);
+    ORACLE_IS_HEALTHY.set(oracle_health.status as i64);
 }
 
 fn update_reward_tokens_in_buyback_box(oracle_pool: Arc<OraclePool>) {

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -24,7 +24,9 @@ use crate::oracle_state::OraclePool;
 
 static POOL_BOX_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {
     let m = IntGaugeVec::new(
-        Opts::new("pool_box_height", "The height of the pool box"),
+        Opts::new("pool_box_height", "The height of the pool box")
+            .namespace("ergo")
+            .subsystem("oracle"),
         &["pool"],
     )
     .unwrap();
@@ -33,13 +35,25 @@ static POOL_BOX_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {
 });
 
 static CURRENT_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {
-    let m = IntGaugeVec::new(Opts::new("current_height", "The current height"), &["pool"]).unwrap();
+    let m = IntGaugeVec::new(
+        Opts::new("current_height", "The current height")
+            .namespace("ergo")
+            .subsystem("oracle"),
+        &["pool"],
+    )
+    .unwrap();
     prometheus::register(Box::new(m.clone())).expect("Failed to register");
     m
 });
 
 static EPOCH_LENGTH: Lazy<IntGaugeVec> = Lazy::new(|| {
-    let m = IntGaugeVec::new(Opts::new("epoch_length", "The epoch length"), &["pool"]).unwrap();
+    let m = IntGaugeVec::new(
+        Opts::new("epoch_length", "The epoch length")
+            .namespace("ergo")
+            .subsystem("oracle"),
+        &["pool"],
+    )
+    .unwrap();
     prometheus::register(Box::new(m.clone())).expect("Failed to register");
     m
 });
@@ -49,7 +63,9 @@ static POOL_IS_HEALTHY: Lazy<IntGaugeVec> = Lazy::new(|| {
         Opts::new(
             "pool_is_healthy",
             "The health status of the pool, 1 for Ok and 0 for Down",
-        ),
+        )
+        .namespace("ergo")
+        .subsystem("oracle"),
         &["pool"],
     )
     .unwrap();

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -44,10 +44,10 @@ static EPOCH_LENGTH: Lazy<IntGaugeVec> = Lazy::new(|| {
     m
 });
 
-static POOL_STATUS: Lazy<IntGaugeVec> = Lazy::new(|| {
+static POOL_IS_HEALTHY: Lazy<IntGaugeVec> = Lazy::new(|| {
     let m = IntGaugeVec::new(
         Opts::new(
-            "pool_health_status",
+            "pool_is_healthy",
             "The health status of the pool, 1 for Ok and 0 for Down",
         ),
         &["pool"],
@@ -69,11 +69,11 @@ pub fn update_pool_health(pool_health: &PoolHealth) {
         .with_label_values(&[pool_name])
         .set(pool_health.details.epoch_length.into());
 
-    let status = match pool_health.status {
+    let health = match pool_health.status {
         PoolStatus::Ok => 1,
         PoolStatus::Down => 0,
     };
-    POOL_STATUS.with_label_values(&[pool_name]).set(status);
+    POOL_IS_HEALTHY.with_label_values(&[pool_name]).set(health);
 }
 
 pub fn update_metrics(oracle_pool: Arc<OraclePool>) -> Result<(), anyhow::Error> {

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -25,95 +25,87 @@ use crate::monitor::PoolHealth;
 use crate::node_interface::node_api::NodeApi;
 use crate::oracle_config::ORACLE_CONFIG;
 use crate::oracle_state::OraclePool;
-use crate::oracle_types::Rate;
 
-static POOL_BOX_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {
-    let m = IntGaugeVec::new(
+static POOL_BOX_HEIGHT: Lazy<IntGauge> = Lazy::new(|| {
+    let m = IntGauge::with_opts(
         Opts::new("pool_box_height", "The height of the pool box")
             .namespace("ergo")
             .subsystem("oracle"),
-        &["pool"],
     )
     .unwrap();
     prometheus::register(Box::new(m.clone())).expect("Failed to register");
     m
 });
 
-static POOL_BOX_RATE: Lazy<IntGaugeVec> = Lazy::new(|| {
-    let m = IntGaugeVec::new(
+static POOL_BOX_RATE: Lazy<IntGauge> = Lazy::new(|| {
+    let m = IntGauge::with_opts(
         Opts::new("pool_box_rate", "exchange rate from the pool box")
             .namespace("ergo")
             .subsystem("oracle"),
-        &["pool"],
     )
     .unwrap();
     prometheus::register(Box::new(m.clone())).expect("Failed to register");
     m
 });
 
-static POOL_BOX_REWARD_TOKEN_AMOUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
-    let m = IntGaugeVec::new(
+static POOL_BOX_REWARD_TOKEN_AMOUNT: Lazy<IntGauge> = Lazy::new(|| {
+    let m = IntGauge::with_opts(
         Opts::new(
             "pool_box_reward_token_amount",
             "The amount of reward token in the pool box",
         )
         .namespace("ergo")
         .subsystem("oracle"),
-        &["pool"],
     )
     .unwrap();
     prometheus::register(Box::new(m.clone())).expect("Failed to register");
     m
 });
 
-static CURRENT_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {
-    let m = IntGaugeVec::new(
+static CURRENT_HEIGHT: Lazy<IntGauge> = Lazy::new(|| {
+    let m = IntGauge::with_opts(
         Opts::new("current_height", "The current height")
             .namespace("ergo")
             .subsystem("oracle"),
-        &["pool"],
     )
     .unwrap();
     prometheus::register(Box::new(m.clone())).expect("Failed to register");
     m
 });
 
-static EPOCH_LENGTH: Lazy<IntGaugeVec> = Lazy::new(|| {
-    let m = IntGaugeVec::new(
+static EPOCH_LENGTH: Lazy<IntGauge> = Lazy::new(|| {
+    let m = IntGauge::with_opts(
         Opts::new("epoch_length", "The epoch length")
             .namespace("ergo")
             .subsystem("oracle"),
-        &["pool"],
     )
     .unwrap();
     prometheus::register(Box::new(m.clone())).expect("Failed to register");
     m
 });
 
-static POOL_IS_HEALTHY: Lazy<IntGaugeVec> = Lazy::new(|| {
-    let m = IntGaugeVec::new(
+static POOL_IS_HEALTHY: Lazy<IntGauge> = Lazy::new(|| {
+    let m = IntGauge::with_opts(
         Opts::new(
             "pool_is_healthy",
             "The health status of the pool, 1 for Ok and 0 for Down",
         )
         .namespace("ergo")
         .subsystem("oracle"),
-        &["pool"],
     )
     .unwrap();
     prometheus::register(Box::new(m.clone())).expect("Failed to register");
     m
 });
 
-static ORACLE_IS_HEALTHY: Lazy<IntGaugeVec> = Lazy::new(|| {
-    let m = IntGaugeVec::new(
+static ORACLE_IS_HEALTHY: Lazy<IntGauge> = Lazy::new(|| {
+    let m = IntGauge::with_opts(
         Opts::new(
             "oracle_is_healthy",
             "The health status of the oracle, 1 for Ok and 0 for Down",
         )
         .namespace("ergo")
         .subsystem("oracle"),
-        &["pool"],
     )
     .unwrap();
     prometheus::register(Box::new(m.clone())).expect("Failed to register");
@@ -128,7 +120,7 @@ static MY_ORACLE_BOX_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {
         )
         .namespace("ergo")
         .subsystem("oracle"),
-        &["pool", "box_type"],
+        &["box_type"],
     )
     .unwrap();
     prometheus::register(Box::new(m.clone())).expect("Failed to register");
@@ -143,7 +135,7 @@ static ALL_ORACLE_BOX_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {
         )
         .namespace("ergo")
         .subsystem("oracle"),
-        &["pool", "box_type", "oracle_address"],
+        &["box_type", "oracle_address"],
     )
     .unwrap();
     prometheus::register(Box::new(m.clone())).expect("Failed to register");
@@ -158,7 +150,7 @@ static ACTIVE_ORACLE_BOX_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {
         )
         .namespace("ergo")
         .subsystem("oracle"),
-        &["pool", "box_type", "oracle_address"],
+        &["box_type", "oracle_address"],
     )
     .unwrap();
     prometheus::register(Box::new(m.clone())).expect("Failed to register");
@@ -190,30 +182,28 @@ static REQUIRED_ORACLE_COUNT: Lazy<IntGauge> = Lazy::new(|| {
     m
 });
 
-static ORACLE_NODE_WALLET_BALANCE: Lazy<IntGaugeVec> = Lazy::new(|| {
-    let m = IntGaugeVec::new(
+static ORACLE_NODE_WALLET_BALANCE: Lazy<IntGauge> = Lazy::new(|| {
+    let m = IntGauge::with_opts(
         Opts::new(
             "oracle_node_wallet_nano_erg",
             "Coins in the oracle's node wallet",
         )
         .namespace("ergo")
         .subsystem("oracle"),
-        &["pool"],
     )
     .unwrap();
     prometheus::register(Box::new(m.clone())).expect("Failed to register");
     m
 });
 
-static REWARD_TOKENS_IN_BUYBACK_BOX: Lazy<IntGaugeVec> = Lazy::new(|| {
-    let m = IntGaugeVec::new(
+static REWARD_TOKENS_IN_BUYBACK_BOX: Lazy<IntGauge> = Lazy::new(|| {
+    let m = IntGauge::with_opts(
         Opts::new(
             "reward_tokens_in_buyback_box",
             "The amount of reward tokens in the buyback box",
         )
         .namespace("ergo")
         .subsystem("oracle"),
-        &["pool"],
     )
     .unwrap();
     prometheus::register(Box::new(m.clone())).expect("Failed to register");
@@ -221,33 +211,26 @@ static REWARD_TOKENS_IN_BUYBACK_BOX: Lazy<IntGaugeVec> = Lazy::new(|| {
 });
 
 fn update_pool_health(pool_health: &PoolHealth) {
-    let pool_name = "pool";
-    POOL_BOX_HEIGHT
-        .with_label_values(&[pool_name])
-        .set(pool_health.details.pool_box_height.into());
-    CURRENT_HEIGHT
-        .with_label_values(&[pool_name])
-        .set(pool_health.details.current_height.into());
-    EPOCH_LENGTH
-        .with_label_values(&[pool_name])
-        .set(pool_health.details.epoch_length.into());
+    POOL_BOX_HEIGHT.set(pool_health.details.pool_box_height.into());
+    CURRENT_HEIGHT.set(pool_health.details.current_height.into());
+    EPOCH_LENGTH.set(pool_health.details.epoch_length.into());
     let health = match pool_health.status {
         HealthStatus::Ok => 1,
         HealthStatus::Down => 0,
     };
-    POOL_IS_HEALTHY.with_label_values(&[pool_name]).set(health);
+    POOL_IS_HEALTHY.set(health);
     for oracle in &pool_health.details.all_oracles {
         let box_type = oracle.box_height.label_name();
         let box_height = oracle.box_height.oracle_box_height().into();
         ALL_ORACLE_BOX_HEIGHT
-            .with_label_values(&[pool_name, box_type, &oracle.address.to_base58()])
+            .with_label_values(&[box_type, &oracle.address.to_base58()])
             .set(box_height);
     }
     for oracle in &pool_health.details.active_oracles {
         let box_type = oracle.box_height.label_name();
         let box_height = oracle.box_height.oracle_box_height().into();
         ACTIVE_ORACLE_BOX_HEIGHT
-            .with_label_values(&[pool_name, box_type, &oracle.address.to_base58()])
+            .with_label_values(&[box_type, &oracle.address.to_base58()])
             .set(box_height);
     }
     ACTIVE_ORACLE_COUNT.set(pool_health.details.active_oracles.len() as i64);
@@ -255,26 +238,16 @@ fn update_pool_health(pool_health: &PoolHealth) {
 }
 
 fn update_oracle_health(oracle_health: &OracleHealth) {
-    let pool_name = "pool";
     let box_type = oracle_health.details.box_details.label_name();
     MY_ORACLE_BOX_HEIGHT
-        .with_label_values(&[pool_name, box_type])
+        .with_label_values(&[box_type])
         .set(oracle_health.details.box_details.oracle_box_height().into());
 
     let health = match oracle_health.status {
         HealthStatus::Ok => 1,
         HealthStatus::Down => 0,
     };
-    ORACLE_IS_HEALTHY
-        .with_label_values(&[pool_name])
-        .set(health);
-}
-
-fn update_pool_box_rate(rate: Rate) {
-    let pool_name = "pool";
-    POOL_BOX_RATE
-        .with_label_values(&[pool_name])
-        .set(rate.into());
+    ORACLE_IS_HEALTHY.set(health);
 }
 
 fn update_reward_tokens_in_buyback_box(oracle_pool: Arc<OraclePool>) {
@@ -290,10 +263,7 @@ fn update_reward_tokens_in_buyback_box(oracle_pool: Arc<OraclePool>) {
             .reward_token()
             .map(|t| t.amount.into())
             .unwrap_or(0);
-        let pool_name = "pool";
-        REWARD_TOKENS_IN_BUYBACK_BOX
-            .with_label_values(&[pool_name])
-            .set(reward_token_amount);
+        REWARD_TOKENS_IN_BUYBACK_BOX.set(reward_token_amount);
     }
 }
 
@@ -302,7 +272,10 @@ pub fn update_metrics(oracle_pool: Arc<OraclePool>) -> Result<(), anyhow::Error>
     let current_height = (node_api.node.current_block_height()? as u32).into();
     let network_prefix = node_api.get_change_address()?.network();
     let pool_box = &oracle_pool.get_pool_box_source().get_pool_box()?;
-    update_pool_box_rate(pool_box.rate());
+    {
+        let rate = pool_box.rate();
+        POOL_BOX_RATE.set(rate.into());
+    };
     let pool_box_height = pool_box.get_box().creation_height.into();
     let pool_health = check_pool_health(
         current_height,
@@ -314,12 +287,8 @@ pub fn update_metrics(oracle_pool: Arc<OraclePool>) -> Result<(), anyhow::Error>
     let oracle_health = check_oracle_health(oracle_pool.clone(), pool_box_height)?;
     update_oracle_health(&oracle_health);
     let wallet_balance: i64 = node_api.node.wallet_nano_ergs_balance()? as i64;
-    ORACLE_NODE_WALLET_BALANCE
-        .with_label_values(&["pool"])
-        .set(wallet_balance);
-    POOL_BOX_REWARD_TOKEN_AMOUNT
-        .with_label_values(&["pool"])
-        .set(pool_box.reward_token().amount.into());
+    ORACLE_NODE_WALLET_BALANCE.set(wallet_balance);
+    POOL_BOX_REWARD_TOKEN_AMOUNT.set(pool_box.reward_token().amount.into());
     update_reward_tokens_in_buyback_box(oracle_pool);
     Ok(())
 }

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -247,7 +247,7 @@ fn update_oracle_health(oracle_health: &OracleHealth) {
         HealthStatus::Ok => 1,
         HealthStatus::Down => 0,
     };
-    ORACLE_IS_HEALTHY.set(0);
+    ORACLE_IS_HEALTHY.set(health);
 }
 
 fn update_reward_tokens_in_buyback_box(oracle_pool: Arc<OraclePool>) {

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -7,13 +7,85 @@ use axum::response::Response;
 use axum::routing::get;
 use axum::Router;
 use ergo_node_interface::scanning::NodeError;
+use once_cell::sync::Lazy;
 use prometheus::Encoder;
-use prometheus::Registry;
+use prometheus::IntGaugeVec;
+use prometheus::Opts;
 use prometheus::TextEncoder;
 use reqwest::StatusCode;
 use tower_http::cors::CorsLayer;
 
-async fn serve_metrics(registry: Arc<Registry>) -> impl IntoResponse {
+use crate::monitor::check_pool_health;
+use crate::monitor::PoolHealth;
+use crate::monitor::PoolStatus;
+use crate::node_interface::node_api::NodeApi;
+use crate::oracle_config::ORACLE_CONFIG;
+use crate::oracle_state::OraclePool;
+
+static POOL_BOX_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {
+    let m = IntGaugeVec::new(
+        Opts::new("pool_box_height", "The height of the pool box"),
+        &["pool"],
+    )
+    .unwrap();
+    prometheus::register(Box::new(m.clone())).expect("Failed to register");
+    m
+});
+
+static CURRENT_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {
+    let m = IntGaugeVec::new(Opts::new("current_height", "The current height"), &["pool"]).unwrap();
+    prometheus::register(Box::new(m.clone())).expect("Failed to register");
+    m
+});
+
+static EPOCH_LENGTH: Lazy<IntGaugeVec> = Lazy::new(|| {
+    let m = IntGaugeVec::new(Opts::new("epoch_length", "The epoch length"), &["pool"]).unwrap();
+    prometheus::register(Box::new(m.clone())).expect("Failed to register");
+    m
+});
+
+static POOL_STATUS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    let m = IntGaugeVec::new(
+        Opts::new(
+            "pool_health_status",
+            "The health status of the pool, 1 for Ok and 0 for Down",
+        ),
+        &["pool"],
+    )
+    .unwrap();
+    prometheus::register(Box::new(m.clone())).expect("Failed to register");
+    m
+});
+
+pub fn update_pool_health(pool_health: &PoolHealth) {
+    let pool_name = "pool";
+    POOL_BOX_HEIGHT
+        .with_label_values(&[pool_name])
+        .set(pool_health.details.pool_box_height.into());
+    CURRENT_HEIGHT
+        .with_label_values(&[pool_name])
+        .set(pool_health.details.current_height.into());
+    EPOCH_LENGTH
+        .with_label_values(&[pool_name])
+        .set(pool_health.details.epoch_length.into());
+
+    let status = match pool_health.status {
+        PoolStatus::Ok => 1,
+        PoolStatus::Down => 0,
+    };
+    POOL_STATUS.with_label_values(&[pool_name]).set(status);
+}
+
+pub fn update_metrics(oracle_pool: Arc<OraclePool>) -> Result<(), anyhow::Error> {
+    let node_api = NodeApi::new(ORACLE_CONFIG.node_api_key.clone(), &ORACLE_CONFIG.node_url);
+    let current_height = (node_api.node.current_block_height()? as u32).into();
+    let pool_health = check_pool_health(oracle_pool, current_height)?;
+    update_pool_health(&pool_health);
+    Ok(())
+}
+
+async fn serve_metrics() -> impl IntoResponse {
+    let registry = prometheus::default_registry();
     let metric_families = registry.gather();
     let mut buffer = vec![];
     let encoder = TextEncoder::new();
@@ -26,15 +98,14 @@ async fn serve_metrics(registry: Arc<Registry>) -> impl IntoResponse {
         .unwrap()
 }
 
-pub async fn start_metrics_server(reg: Arc<Registry>, port_num: u16) -> Result<(), anyhow::Error> {
-    let app = Router::new()
-        .route("/metrics", get(move || serve_metrics(reg.clone())))
-        .layer(
-            CorsLayer::new()
-                .allow_origin(tower_http::cors::Any)
-                .allow_methods([axum::http::Method::GET]),
-        );
+pub async fn start_metrics_server(port_num: u16) -> Result<(), anyhow::Error> {
+    let app = Router::new().route("/metrics", get(serve_metrics)).layer(
+        CorsLayer::new()
+            .allow_origin(tower_http::cors::Any)
+            .allow_methods([axum::http::Method::GET]),
+    );
     let addr = SocketAddr::from(([0, 0, 0, 0], port_num));
+    log::info!("Starting metrics server on {}", addr);
     axum::Server::try_bind(&addr)?
         .serve(app.into_make_service())
         .await?;

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -51,6 +51,21 @@ static POOL_BOX_RATE: Lazy<IntGaugeVec> = Lazy::new(|| {
     m
 });
 
+static POOL_BOX_REWARD_TOKEN_AMOUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
+    let m = IntGaugeVec::new(
+        Opts::new(
+            "pool_box_reward_token_amount",
+            "The amount of reward token in the pool box",
+        )
+        .namespace("ergo")
+        .subsystem("oracle"),
+        &["pool"],
+    )
+    .unwrap();
+    prometheus::register(Box::new(m.clone())).expect("Failed to register");
+    m
+});
+
 static CURRENT_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {
     let m = IntGaugeVec::new(
         Opts::new("current_height", "The current height")
@@ -194,6 +209,9 @@ pub fn update_metrics(oracle_pool: Arc<OraclePool>) -> Result<(), anyhow::Error>
     ORACLE_NODE_WALLET_BALANCE
         .with_label_values(&["pool"])
         .set(wallet_balance);
+    POOL_BOX_REWARD_TOKEN_AMOUNT
+        .with_label_values(&["pool"])
+        .set(pool_box.reward_token().amount.into());
     Ok(())
 }
 

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -1,0 +1,62 @@
+use std::convert::From;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::response::IntoResponse;
+use axum::response::Response;
+use axum::routing::get;
+use axum::Router;
+use ergo_node_interface::scanning::NodeError;
+use prometheus::Encoder;
+use prometheus::Registry;
+use prometheus::TextEncoder;
+use reqwest::StatusCode;
+use tower_http::cors::CorsLayer;
+
+async fn serve_metrics(registry: Arc<Registry>) -> impl IntoResponse {
+    let metric_families = registry.gather();
+    let mut buffer = vec![];
+    let encoder = TextEncoder::new();
+    encoder.encode(&metric_families, &mut buffer).unwrap();
+
+    let metrics = String::from_utf8(buffer).unwrap();
+    axum::response::Response::builder()
+        .header("Content-Type", encoder.format_type())
+        .body(metrics)
+        .unwrap()
+}
+
+pub async fn start_metrics_server(reg: Arc<Registry>, port_num: u16) -> Result<(), anyhow::Error> {
+    let app = Router::new()
+        .route("/metrics", get(move || serve_metrics(reg.clone())))
+        .layer(
+            CorsLayer::new()
+                .allow_origin(tower_http::cors::Any)
+                .allow_methods([axum::http::Method::GET]),
+        );
+    let addr = SocketAddr::from(([0, 0, 0, 0], port_num));
+    axum::Server::try_bind(&addr)?
+        .serve(app.into_make_service())
+        .await?;
+    Ok(())
+}
+
+struct MetricsError(String);
+
+impl From<NodeError> for MetricsError {
+    fn from(err: NodeError) -> Self {
+        MetricsError(format!("NodeError: {}", err))
+    }
+}
+
+impl IntoResponse for MetricsError {
+    fn into_response(self) -> Response {
+        (StatusCode::INTERNAL_SERVER_ERROR, self.0).into_response()
+    }
+}
+
+impl From<anyhow::Error> for MetricsError {
+    fn from(err: anyhow::Error) -> Self {
+        MetricsError(format!("Error: {:?}", err))
+    }
+}

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -247,7 +247,7 @@ fn update_oracle_health(oracle_health: &OracleHealth) {
         HealthStatus::Ok => 1,
         HealthStatus::Down => 0,
     };
-    ORACLE_IS_HEALTHY.set(health);
+    ORACLE_IS_HEALTHY.set(0);
 }
 
 fn update_reward_tokens_in_buyback_box(oracle_pool: Arc<OraclePool>) {

--- a/core/src/monitor.rs
+++ b/core/src/monitor.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
-use crate::box_kind::PoolBox;
+use crate::box_kind::OracleBoxWrapper;
 use crate::oracle_state::OraclePool;
 use crate::oracle_types::BlockHeight;
 use crate::oracle_types::EpochLength;
 use crate::pool_config::POOL_CONFIG;
 
 #[derive(Debug, serde::Serialize)]
-pub enum PoolStatus {
+pub enum HealthStatus {
     Ok,
     Down,
 }
@@ -21,21 +21,15 @@ pub struct PoolHealthDetails {
 
 #[derive(Debug, serde::Serialize)]
 pub struct PoolHealth {
-    pub status: PoolStatus,
+    pub status: HealthStatus,
     pub details: PoolHealthDetails,
 }
 
 pub fn check_pool_health(
-    oracle_pool: Arc<OraclePool>,
     current_height: BlockHeight,
+    pool_box_height: BlockHeight,
 ) -> Result<PoolHealth, anyhow::Error> {
     let pool_conf = &POOL_CONFIG;
-    let pool_box_height = oracle_pool
-        .get_pool_box_source()
-        .get_pool_box()?
-        .get_box()
-        .creation_height
-        .into();
     let epoch_length = pool_conf
         .refresh_box_wrapper_inputs
         .contract_inputs
@@ -48,9 +42,9 @@ pub fn check_pool_health(
         pool_box_height >= current_height - epoch_length - acceptable_pool_box_delay_blocks;
     Ok(PoolHealth {
         status: if is_healthy {
-            PoolStatus::Ok
+            HealthStatus::Ok
         } else {
-            PoolStatus::Down
+            HealthStatus::Down
         },
         details: PoolHealthDetails {
             pool_box_height,
@@ -58,4 +52,72 @@ pub fn check_pool_health(
             epoch_length,
         },
     })
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct OracleHealth {
+    pub status: HealthStatus,
+    pub details: OracleHealthDetails,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub enum OracleBoxDetails {
+    PostedBox(BlockHeight),
+    CollectedBox(BlockHeight),
+}
+
+impl OracleBoxDetails {
+    pub fn oracle_box_height(&self) -> BlockHeight {
+        match self {
+            OracleBoxDetails::PostedBox(height) => *height,
+            OracleBoxDetails::CollectedBox(height) => *height,
+        }
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct OracleHealthDetails {
+    pub pool_box_height: BlockHeight,
+    pub box_details: OracleBoxDetails,
+}
+
+pub fn check_oracle_health(
+    oracle_pool: Arc<OraclePool>,
+    pool_box_height: BlockHeight,
+) -> Result<OracleHealth, anyhow::Error> {
+    let health = match oracle_pool
+        .get_local_datapoint_box_source()
+        .get_local_oracle_datapoint_box()?
+        .ok_or_else(|| anyhow::anyhow!("Oracle box not found"))?
+    {
+        OracleBoxWrapper::Posted(posted_box) => {
+            let posted_box_height = posted_box.get_box().creation_height.into();
+            OracleHealth {
+                status: if posted_box_height > pool_box_height {
+                    HealthStatus::Ok
+                } else {
+                    HealthStatus::Down
+                },
+                details: OracleHealthDetails {
+                    pool_box_height,
+                    box_details: OracleBoxDetails::PostedBox(posted_box_height),
+                },
+            }
+        }
+        OracleBoxWrapper::Collected(collected_box) => {
+            let creation_height = collected_box.get_box().creation_height.into();
+            OracleHealth {
+                status: if creation_height == pool_box_height {
+                    HealthStatus::Ok
+                } else {
+                    HealthStatus::Down
+                },
+                details: OracleHealthDetails {
+                    pool_box_height,
+                    box_details: OracleBoxDetails::PostedBox(creation_height),
+                },
+            }
+        }
+    };
+    Ok(health)
 }

--- a/core/src/monitor.rs
+++ b/core/src/monitor.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+
+use crate::box_kind::PoolBox;
+use crate::oracle_state::OraclePool;
+use crate::oracle_types::BlockHeight;
+use crate::oracle_types::EpochLength;
+use crate::pool_config::POOL_CONFIG;
+
+#[derive(Debug, serde::Serialize)]
+pub enum PoolStatus {
+    Ok,
+    Down,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct PoolHealthDetails {
+    pub pool_box_height: BlockHeight,
+    pub current_height: BlockHeight,
+    pub epoch_length: EpochLength,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct PoolHealth {
+    pub status: PoolStatus,
+    pub details: PoolHealthDetails,
+}
+
+pub fn check_pool_health(
+    oracle_pool: Arc<OraclePool>,
+    current_height: BlockHeight,
+) -> Result<PoolHealth, anyhow::Error> {
+    let pool_conf = &POOL_CONFIG;
+    let pool_box_height = oracle_pool
+        .get_pool_box_source()
+        .get_pool_box()?
+        .get_box()
+        .creation_height
+        .into();
+    let epoch_length = pool_conf
+        .refresh_box_wrapper_inputs
+        .contract_inputs
+        .contract_parameters()
+        .epoch_length()
+        .0
+        .into();
+    let acceptable_pool_box_delay_blocks = 3;
+    let is_healthy =
+        pool_box_height >= current_height - epoch_length - acceptable_pool_box_delay_blocks;
+    Ok(PoolHealth {
+        status: if is_healthy {
+            PoolStatus::Ok
+        } else {
+            PoolStatus::Down
+        },
+        details: PoolHealthDetails {
+            pool_box_height,
+            current_height,
+            epoch_length,
+        },
+    })
+}

--- a/core/src/monitor.rs
+++ b/core/src/monitor.rs
@@ -14,10 +14,16 @@ use crate::oracle_types::EpochLength;
 use crate::oracle_types::MinDatapoints;
 use crate::pool_config::POOL_CONFIG;
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, serde::Serialize, Copy, Clone)]
 pub enum HealthStatus {
-    Ok,
-    Down,
+    Ok = 1,
+    Down = 0,
+}
+
+impl HealthStatus {
+    pub fn get_integer_value(&self) -> i32 {
+        *self as i32
+    }
 }
 
 #[derive(Debug, serde::Serialize)]

--- a/core/src/monitor.rs
+++ b/core/src/monitor.rs
@@ -114,7 +114,7 @@ pub fn check_oracle_health(
                 },
                 details: OracleHealthDetails {
                     pool_box_height,
-                    box_details: OracleBoxDetails::PostedBox(creation_height),
+                    box_details: OracleBoxDetails::CollectedBox(creation_height),
                 },
             }
         }

--- a/core/src/monitor.rs
+++ b/core/src/monitor.rs
@@ -11,6 +11,7 @@ use crate::oracle_state::DataSourceError;
 use crate::oracle_state::OraclePool;
 use crate::oracle_types::BlockHeight;
 use crate::oracle_types::EpochLength;
+use crate::oracle_types::MinDatapoints;
 use crate::pool_config::POOL_CONFIG;
 
 #[derive(Debug, serde::Serialize)]
@@ -26,6 +27,7 @@ pub struct PoolHealthDetails {
     pub epoch_length: EpochLength,
     pub all_oracles: Vec<OracleDetails>,
     pub active_oracles: Vec<OracleDetails>,
+    pub min_data_points: MinDatapoints,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -71,6 +73,11 @@ pub fn check_pool_health(
             epoch_length,
             all_oracles,
             active_oracles,
+            min_data_points: pool_conf
+                .refresh_box_wrapper_inputs
+                .contract_inputs
+                .contract_parameters()
+                .min_data_points(),
         },
     })
 }

--- a/core/src/oracle_config.rs
+++ b/core/src/oracle_config.rs
@@ -117,7 +117,3 @@ lazy_static! {
         .unwrap_or_else(|_| SUGGESTED_TX_FEE());
 }
 
-/// Returns "core_api_port" from the config file
-pub fn get_core_api_port() -> String {
-    ORACLE_CONFIG.core_api_port.to_string()
-}

--- a/core/src/oracle_config.rs
+++ b/core/src/oracle_config.rs
@@ -35,6 +35,7 @@ pub struct OracleConfig {
     pub oracle_address: NetworkAddress,
     pub data_point_source_custom_script: Option<String>,
     pub explorer_url: Option<Url>,
+    pub metrics_port: Option<u16>,
 }
 
 impl OracleConfig {
@@ -102,6 +103,7 @@ impl Default for OracleConfig {
             log_level: LevelFilter::Info.into(),
             node_url: Url::parse("http://127.0.0.1:9053").unwrap(),
             explorer_url: Some(default_explorer_api_url(address.network())),
+            metrics_port: None,
         }
     }
 }
@@ -116,4 +118,3 @@ lazy_static! {
         .map(|c| BoxValue::try_from(c.base_fee).unwrap())
         .unwrap_or_else(|_| SUGGESTED_TX_FEE());
 }
-

--- a/core/src/oracle_state.rs
+++ b/core/src/oracle_state.rs
@@ -7,7 +7,7 @@ use crate::box_kind::{
 };
 use crate::datapoint_source::DataPointSourceError;
 use crate::oracle_config::ORACLE_CONFIG;
-use crate::oracle_types::{BlockHeight, EpochCounter};
+use crate::oracle_types::{BlockHeight, EpochCounter, Rate};
 use crate::pool_config::POOL_CONFIG;
 use crate::scans::{GenericTokenScan, NodeScanRegistry, ScanError, ScanGetBoxes};
 use crate::spec_token::{
@@ -154,7 +154,7 @@ pub struct BuybackBoxScan {
 pub struct LiveEpochState {
     pub pool_box_epoch_id: EpochCounter,
     pub local_datapoint_box_state: Option<LocalDatapointState>,
-    pub latest_pool_datapoint: u64,
+    pub latest_pool_datapoint: Rate,
     pub latest_pool_box_height: BlockHeight,
 }
 
@@ -261,7 +261,7 @@ impl OraclePool {
                 },
             });
 
-        let latest_pool_datapoint = pool_box.rate() as u64;
+        let latest_pool_datapoint = pool_box.rate();
 
         let epoch_state = LiveEpochState {
             pool_box_epoch_id: epoch_id,

--- a/core/src/oracle_types.rs
+++ b/core/src/oracle_types.rs
@@ -10,7 +10,7 @@ use derive_more::Sub;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize, Copy, Clone)]
+#[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize, Copy, Clone, From)]
 #[serde(transparent)]
 pub struct BlockHeight(pub u32);
 
@@ -18,6 +18,21 @@ impl std::ops::Sub<EpochLength> for BlockHeight {
     type Output = BlockHeight;
     fn sub(self, other: EpochLength) -> BlockHeight {
         BlockHeight(self.0 - other.0 as u32)
+    }
+}
+
+impl std::ops::Add<EpochLength> for BlockHeight {
+    type Output = BlockHeight;
+    fn add(self, other: EpochLength) -> BlockHeight {
+        BlockHeight(self.0 + other.0 as u32)
+    }
+}
+
+impl std::ops::Add<u32> for BlockHeight {
+    type Output = BlockHeight;
+    fn add(self, other: u32) -> BlockHeight {
+        // Unwrap here to panic on overflow instead of wrapping around
+        BlockHeight(self.0.checked_add(other).unwrap())
     }
 }
 
@@ -29,21 +44,33 @@ impl std::ops::Sub<u32> for BlockHeight {
     }
 }
 
+impl From<BlockHeight> for i64 {
+    fn from(block_height: BlockHeight) -> Self {
+        block_height.0 as i64
+    }
+}
+
 impl std::fmt::Display for BlockHeight {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-#[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize, Copy, Clone)]
+#[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize, Copy, Clone, From)]
 #[serde(transparent)]
 pub struct EpochLength(pub i32);
 
-#[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize, Copy, Clone)]
+impl From<EpochLength> for i64 {
+    fn from(epoch_length: EpochLength) -> Self {
+        epoch_length.0 as i64
+    }
+}
+
+#[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize, Copy, Clone, From)]
 #[serde(transparent)]
 pub struct EpochCounter(pub u32);
 
-#[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize, Copy, Clone)]
+#[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize, Copy, Clone, From)]
 #[serde(transparent)]
 pub struct MinDatapoints(pub i32);
 

--- a/core/src/oracle_types.rs
+++ b/core/src/oracle_types.rs
@@ -74,6 +74,12 @@ pub struct EpochCounter(pub u32);
 #[serde(transparent)]
 pub struct MinDatapoints(pub i32);
 
+impl From<MinDatapoints> for i64 {
+    fn from(min_datapoints: MinDatapoints) -> Self {
+        min_datapoints.0 as i64
+    }
+}
+
 #[derive(
     PartialEq,
     PartialOrd,

--- a/core/src/scans.rs
+++ b/core/src/scans.rs
@@ -1,4 +1,3 @@
-use crate::address_util::AddressUtilError;
 use crate::contracts::pool::PoolContractError;
 use crate::contracts::refresh::RefreshContractError;
 use crate::node_interface::node_api::{NodeApi, NodeApiError};
@@ -34,8 +33,6 @@ pub enum ScanError {
     RefreshContract(#[from] RefreshContractError),
     #[error("pool contract error: {0}")]
     PoolContract(#[from] PoolContractError),
-    #[error("address util error: {0}")]
-    AddressUtilError(#[from] AddressUtilError),
 }
 
 pub trait NodeScanId {

--- a/scripts/grafana_dashboard.json
+++ b/scripts/grafana_dashboard.json
@@ -1,0 +1,900 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            }
+        ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 6,
+    "links": [],
+    "panels": [
+        {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 24,
+            "panels": [],
+            "title": "Pool",
+            "type": "row"
+        },
+        {
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "from": "",
+                            "id": 1,
+                            "text": "OK",
+                            "to": "",
+                            "type": 1,
+                            "value": "1"
+                        },
+                        {
+                            "from": "",
+                            "id": 2,
+                            "text": "DOWN",
+                            "to": "",
+                            "type": 1,
+                            "value": "0"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 2,
+                "x": 0,
+                "y": 1
+            },
+            "id": 6,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "ergo_oracle_pool_is_healthy",
+                    "format": "time_series",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Pool health",
+            "transformations": [],
+            "type": "stat"
+        },
+        {
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 3,
+                "x": 2,
+                "y": 1
+            },
+            "id": 32,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "ergo_oracle_active_oracle_count",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Active oracle count",
+            "type": "stat"
+        },
+        {
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 3,
+                "x": 5,
+                "y": 1
+            },
+            "id": 34,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "ergo_oracle_required_oracle_count",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Min required oracle count",
+            "type": "stat"
+        },
+        {
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 3,
+                "x": 8,
+                "y": 1
+            },
+            "id": 18,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "ergo_oracle_pool_box_height",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Pool box height",
+            "type": "stat"
+        },
+        {
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 11,
+                "y": 1
+            },
+            "id": 16,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "ergo_oracle_pool_box_reward_token_amount",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Reward token amount in the pool box",
+            "type": "stat"
+        },
+        {
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 15,
+                "y": 1
+            },
+            "id": 12,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "ergo_oracle_pool_box_rate",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Rate in pool box",
+            "type": "stat"
+        },
+        {
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 19,
+                "y": 1
+            },
+            "id": 26,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "ergo_oracle_reward_tokens_in_buyback_box",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Reward tokens in buyback box",
+            "type": "stat"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 17,
+                "w": 23,
+                "x": 0,
+                "y": 6
+            },
+            "hiddenSeries": false,
+            "id": 30,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.11",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "ergo_oracle_active_oracle_box_height",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Active oracle boxes heights",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:1025",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:1026",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 23
+            },
+            "id": 22,
+            "panels": [],
+            "title": "Oracle",
+            "type": "row"
+        },
+        {
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "from": "",
+                            "id": 1,
+                            "text": "OK",
+                            "to": "",
+                            "type": 1,
+                            "value": "1"
+                        },
+                        {
+                            "from": "",
+                            "id": 2,
+                            "text": "Down",
+                            "to": "",
+                            "type": 1,
+                            "value": "0"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 5,
+                "x": 0,
+                "y": 24
+            },
+            "id": 10,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "ergo_oracle_oracle_is_healthy",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Oracle health",
+            "type": "stat"
+        },
+        {
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 5,
+                "y": 24
+            },
+            "id": 20,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "ergo_oracle_current_height",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Node height",
+            "type": "stat"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 15,
+                "w": 11,
+                "x": 11,
+                "y": 24
+            },
+            "hiddenSeries": false,
+            "id": 2,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.11",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "ergo_oracle_pool_box_height",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A"
+                },
+                {
+                    "exemplar": true,
+                    "expr": "ergo_oracle_current_height",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "B"
+                },
+                {
+                    "exemplar": true,
+                    "expr": "ergo_oracle_oracle_box_height",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "C"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Pool box, oracle box, node heights",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:221",
+                    "format": "short",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:222",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 11,
+                "x": 0,
+                "y": 31
+            },
+            "id": 14,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "ergo_oracle_oracle_node_wallet_nano_erg",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Nano ERGs in node's wallet",
+            "type": "stat"
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 27,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": []
+    },
+    "time": {
+        "from": "now-1h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Ergo oracle",
+    "uid": "ORWMfHl4k",
+    "version": 33
+}


### PR DESCRIPTION
Close #53 #266

This PR add exporting Prometheus metrics for various oracle and pool states. It unifies metrics served via REST API `/poolHealth`, `/oracleHealth` and Prometheus metrics in `metrics.rs`. Also, Grafana dashboard is added in `/scripts/grafana_dashboard.json`.
