### PR TITLE
Fix docker release Github action

### DIFF
--- a/.github/workflows/docker_crossbuild_publish.yml
+++ b/.github/workflows/docker_crossbuild_publish.yml
@@ -23,11 +23,19 @@ jobs:
      - name: Checkout code
        uses: actions/checkout@v4
 
+     - name: Set up QEMU
+       uses: docker/setup-qemu-action@v3
+
      - name: Set up Docker Buildx
        uses: docker/setup-buildx-action@v3
 
+     - name: Prepare
+       run: |
+         platform=${{ matrix.platform }}
+         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
      - name: Generate Docker metadata
-       id: metadata
+       id: meta
        uses: docker/metadata-action@v5
        with:
          images: ${{ env.REGISTRY_IMAGE }}
@@ -44,25 +52,26 @@ jobs:
        with:
          context: .
          platforms: ${{ matrix.platform }}
-         labels: ${{ steps.metadata.outputs.labels }}
-         outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+         tags: ${{ env.REGISTRY_IMAGE }}
+         labels: ${{ steps.meta.outputs.labels }}
+         outputs: type=image,push-by-digest=true,name-canonical=true,push=true
          build-args: |
            TARGETPLATFORM=${{ matrix.platform }}
            CCARCH=${{ matrix.ccarch }}
            
      - name: Export digest
        run: |
-          mkdir -p /tmp/digests
+          mkdir -p ${{ runner.temp }}/digests
           digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
           
      - name: Upload digest
        uses: actions/upload-artifact@v4
        with:
-         name: digests
-         path: /tmp/digests/*
-         if-no-files-found: error
-         retention-days: 1    
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1 
           
  merge:
    needs: build
@@ -71,14 +80,15 @@ jobs:
      - name: Download digests
        uses: actions/download-artifact@v4
        with:
-         name: digests
-         path: /tmp/digests
+         path: ${{ runner.temp }}/digests
+         pattern: digests-*
+         merge-multiple: true
          
      - name: Set up Docker Buildx
        uses: docker/setup-buildx-action@v3
        
      - name: Generate Docker metadata
-       id: metadata
+       id: meta
        uses: docker/metadata-action@v5
        with:
          images: ${{ env.REGISTRY_IMAGE }}
@@ -92,10 +102,11 @@ jobs:
          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
      - name: Create manifest list and push
-       working-directory: /tmp/digests
+       working-directory: ${{ runner.temp }}/digests
        run: |
          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
      - name: Inspect image
        run: |
-         docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.metadata.outputs.version }}
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
The Docker release workflow has been updated, as per the [Docker documentation](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners).